### PR TITLE
Update elm-package.json example dependency text

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ Add `gdotdesign/elm-spec` as a dependency to your `elm-package.json`.
 
 ```json
   "dependencies": {
-    "gdotdesign/elm-spec": "1.0.0 <= v 2.0.0"
+    "gdotdesign/elm-spec": "1.0.0 <= v < 2.0.0"
   }
 ```
 


### PR DESCRIPTION
The original example text is missing the second less than sign, and causes the following error

```
$ elm-spec spec/LeagueList.elm                                                   
Failed to compile spec/LeagueList.elm:                                           
  -- SYNTAX PROBLDetected errors in 1 module.                                    
  EM ------------------------------------------ spec/LeagueList.elm              
                                                                                 
  I need whitespace, but got stuck on what looks like a new declaration. You are 
  either missing some stuff in the declaration above or just need to add some    
  spaces here:                                                                   
                                                                                 
  20| } specs                                                                    
      ^                                                                          
  I am looking for one of the following things:                                  
                                                                                 
      whitespace                                                                 
```

I have tested the new example text on my environment the error does not occur.